### PR TITLE
【追加】お気に入り登録機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 - has_many :items
 - has_many :orders
 - has_many :comments
+- has_many :likes
+
 
 
 ## itemsテーブル
@@ -40,6 +42,7 @@
 - belongs_to_active_hash :day
 - belongs_to_active_hash :delivery_charge
 - has_many :comments
+- has_many :likes
 
 
 ## ordersテーブル
@@ -70,7 +73,7 @@
 - belongs_to_active_hash :prefecture
 
 
-## 【追加実装】commentsテーブル
+## 【追加実装】 commentsテーブル
 | Column | Type       | Options                        |
 | ------ | ---------- | ------------------------------ |
 | text   | text       | null: false                    |
@@ -80,3 +83,15 @@
 ### Association
 - belongs_to :item
 - belongs_to :user
+
+
+## 【追加実装】 likesテーブル
+| Column | Type       | Options                        |
+| ------ | ---------- | ------------------------------ |
+| item   | references | null: false, foreign_key: true |
+| user   | references | null: false, foreign_key: true |
+
+### Association
+- belongs_to :item
+- belongs_to :user
+- validates_uniqueness_of :item_id, scope: :user_id

--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -114,17 +114,24 @@
   border-radius: 40px;
   width: 15vw;
   min-width: 200px;
-  color: rgb(249, 75, 0);
+  
   border: 2px solid #ffb340;
   display: flex;
   justify-content: center;
   align-items: center;
   margin-right: 20px;
+  background-color: white;
 }
 
 .favorite-star-icon {
   margin-right: 5px;
 }
+
+/* 追加実装 */
+.favorite-btn a {
+  color: rgb(249, 75, 0);
+}
+/* //追加実装 */
 
 .report-btn {
   border-radius: 40px;
@@ -142,7 +149,6 @@
 .report-flag-icon {
   margin-right: 5px;
 }
-
 
 /* /商品の概要 */
 
@@ -184,7 +190,7 @@
   min-width: 150px;
   font-size: 18px;
   border-radius: 100px;
-  margin-bottom: 2vh;
+  margin: 10px 0 2vh 0;
 }
 
 .comment-flag {
@@ -193,7 +199,7 @@
 }
 
 .comment-flag-icon {
-  margin: 10px 5px 0 0;
+  margin: 0 5px 0 0;
 }
 
 .links {

--- a/app/assets/stylesheets/likes.scss
+++ b/app/assets/stylesheets/likes.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the likes controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,6 @@
 class CommentsController < ApplicationController
+  before_action :authenticate_user!
+
   def create
     @comment = Comment.new(comments_params)
     if @comment.save

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,6 +11,7 @@ class ItemsController < ApplicationController
   def show
     @comment = Comment.new
     @comments = @item.comments.includes(:user)
+    @like = Like.new
   end
 
   def new
@@ -39,6 +40,7 @@ class ItemsController < ApplicationController
     if @item.destroy
       redirect_to root_path, notice: '商品を削除しました。'
     else
+      flash[:alart] = '商品を削除できませんでした。'
       render :show
     end
   end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,6 +1,6 @@
 class LikesController < ApplicationController
   before_action :authenticate_user!
-  
+
   def create
     @like = Like.new(like_params)
     if @like.save
@@ -15,7 +15,7 @@ class LikesController < ApplicationController
   end
 
   def destroy
-    if @like = Like.find_by(like_params) 
+    if @like = Like.find_by(like_params)
       @like.destroy
       redirect_to item_path(like_params[:item_id]), notice: 'お気に入りから削除しました。'
     else
@@ -32,5 +32,4 @@ class LikesController < ApplicationController
   def like_params
     params.permit(:item_id).merge(user_id: current_user.id)
   end
-
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,36 @@
+class LikesController < ApplicationController
+  before_action :authenticate_user!
+  
+  def create
+    @like = Like.new(like_params)
+    if @like.save
+      redirect_to item_path(@like.item.id), notice: 'お気に入りに登録しました。'
+    else
+      @search = Item.ransack(params[:q])
+      @item = Item.find(params[:item_id])
+      @comments = @item.comments
+      flash[:alart] = 'お気に入りに登録できませんでした。'
+      render 'items/show'
+    end
+  end
+
+  def destroy
+    if @like = Like.find_by(like_params) 
+      @like.destroy
+      redirect_to item_path(like_params[:item_id]), notice: 'お気に入りから削除しました。'
+    else
+      @search = Item.ransack(params[:q])
+      @item = Item.find(like_params[:item_id])
+      @comments = @item.comments
+      flash[:alart] = 'お気に入りから削除できませんでした。'
+      render 'items/show'
+    end
+  end
+
+  private
+
+  def like_params
+    params.permit(:item_id).merge(user_id: current_user.id)
+  end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,10 +6,10 @@ class UsersController < ApplicationController
   def show # マイページ機能
     @search = Item.ransack(params[:q])
     @items = Item.all.includes(:user).order('created_at DESC')
-
     @comments = @user.comments
     @my_items = @user.items.order('created_at DESC') # 出品した商品
     @comment_items = @items.joins(:comments).distinct.where(comments: { user_id: @user.id }).order('created_at DESC') # コメントした商品
+    @like_items = @items.joins(:likes).distinct.where(likes: { user_id: @user.id }).order('created_at DESC') # お気に入り登録した商品
   end
 
   private

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,0 +1,2 @@
+module LikesHelper
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,8 +1,9 @@
 class Item < ApplicationRecord
   belongs_to :user
   has_one :order
-  has_many_attached :images
-  has_many :comments
+  has_many_attached :images, dependent: :destroy
+  has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :status

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -2,5 +2,4 @@ class Like < ApplicationRecord
   belongs_to :item
   belongs_to :user
   validates_uniqueness_of :item_id, scope: :user_id
-  
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,6 @@
+class Like < ApplicationRecord
+  belongs_to :item
+  belongs_to :user
+  validates_uniqueness_of :item_id, scope: :user_id
+  
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,6 @@ class User < ApplicationRecord
   end
 
   def already_liked?(item) # ユーザーが商品に対して、すでにお気に入り登録をしているのかどうかを判定
-    self.likes.exists?(item_id: item.id)
+    likes.exists?(item_id: item.id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_many :items
   has_many :orders
   has_many :comments
+  has_many :likes
 
   with_options presence: true do
     validates :nickname, :birth_date
@@ -19,5 +20,9 @@ class User < ApplicationRecord
 
     FULL_WIDTH_KATAKANA =  /\A[ァ-ヶー－]+\z/.freeze # 全角カタカナの正規表現
     validates :first_name_kana, :last_name_kana, format: { with: FULL_WIDTH_KATAKANA, message: 'は全角(カナ)で入力してください' }
+  end
+
+  def already_liked?(item) # ユーザーが商品に対して、すでにお気に入り登録をしているのかどうかを判定
+    self.likes.exists?(item_id: item.id)
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -120,42 +120,9 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <% @items.each do |item| %>
-        <li class='list'>
-          <%= link_to item_path(item.id) do %>
-            <div class='item-img-content'>
-              <%# 1枚目の画像のみ表示, S3移行前の画像はno_images.pngに差し替え %>
-              <% if item.images.attached? && item.images.count > 0 %>
-                <%= image_tag item.images.first, class:'item-img' %>
-              <% else %>
-                <%= image_tag 'no_images.png', class: 'item-img' %>
-              <% end %>
-
-              <%# 商品が売れている場合 %>
-              <% if item.order != nil  %>
-                <div class='sold-out'>
-                  <span>Sold Out!!</span>
-                </div>
-              <% end %>  
-
-            </div>
-            <div class='item-info'>
-              <h3 class='item-name'>
-                <%= item.name %>
-              </h3>
-              <div class='item-price'>
-                <span><%= item.price %>円<br>(税込み)</span>
-                <div class='star-btn'>
-                 <%= image_tag "star.png", class:"star-icon" %>
-                  <span class='star-count'>0</span>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        </li>
-       <% end %> 
-
+      <%# 全商品の一覧 %>
+      <%= render partial: "shared/item_lists", locals: { items: @items } %>
+      
       <%# 商品がない場合のダミー %>
       <% if @items == nil %>
         <li class='list'>
@@ -169,7 +136,7 @@
                 <span>99999999円<br>(税込み)</span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>
-                  <span class='star-count'>0</span>
+                  <span class='star-count'><%= item.likes.count %></span>
                 </div>
               </div>
             </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -80,10 +80,16 @@
       </tbody>
     </table>
     <div class="option">
-      <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
-        <span>お気に入り 0</span>
-      </div>
+      <button class="favorite-btn">
+        <%# お気に入り登録の有無で表示を分岐 %>
+        <% if user_signed_in? && Like.find_by(user_id: current_user.id, item_id: @item.id) %> 
+          <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+          <%= link_to "お気に入りから削除", item_like_path(@item), method: :delete %>
+        <% else %>
+          <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+          <%= link_to "お気に入り", item_likes_path(@item, @like), method: :post %>
+        <% end %>
+      </button>
       <div class="report-btn">
         <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
         <span>不適切な商品の通報</span>

--- a/app/views/shared/_item_lists.html.erb
+++ b/app/views/shared/_item_lists.html.erb
@@ -1,0 +1,35 @@
+<% items.each do |item| %>
+  <li class='list'>
+    <%= link_to item_path(item.id) do %>
+      <div class='item-img-content'>
+        <%# 1枚目の画像のみ表示, S3移行前の画像はno_images.pngに差し替え %>
+        <% if item.images.attached? && item.images.count > 0 %>
+          <%= image_tag item.images.first, class:'item-img' %>
+        <% else %>
+          <%= image_tag 'no_images.png', class: 'item-img' %>
+        <% end %>
+
+        <%# 商品が売れている場合 %>
+        <% if item.order != nil  %>
+          <div class='sold-out'>
+            <span>Sold Out!!</span>
+          </div>
+        <% end %>  
+      </div>
+      <div class='item-info'>
+        <h3 class='item-name'>
+          <%= item.name %>
+        </h3>
+        <div class='item-price'>
+          <span><%= item.price %>円<br>(税込み)</span>
+          <%# お気に入り登録数を表示 %>
+          <div class='star-btn'>
+            <%= image_tag "star.png", class:"star-icon" %>
+            <span class='star-count'><%= item.likes.count %></span>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </li>
+<% end %> 
+

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,81 +1,26 @@
 <%= render "shared/header" %>
 <%# 商品一覧 %>
+<%# お気に入り商品 %>
   <div class='item-contents'>
-    <h2 class='title'>コメントした商品</h2>
+    <h2 class='title'>お気に入り商品</h2>
     <ul class='item-lists'>
-      <% @comment_items.each do |item| %>
-        <li class='list'>
-          <%= link_to item_path(item.id) do %>
-            <div class='item-img-content'>
-              <%# 1枚目の画像のみ表示, S3移行前の画像はno_images.pngに差し替え %>
-              <% if item.images.attached? && item.images.count > 0 %>
-                <%= image_tag item.images.first, class:'item-img' %>
-              <% else %>
-                <%= image_tag 'no_images.png', class: 'item-img' %>
-              <% end %>
-
-              <%# 商品が売れている場合 %>
-              <% if item.order != nil  %>
-                <div class='sold-out'>
-                  <span>Sold Out!!</span>
-                </div>
-              <% end %>  
-            </div>
-            <div class='item-info'>
-              <h3 class='item-name'>
-                <%= item.name %>
-              </h3>
-              <div class='item-price'>
-                <span><%= item.price %>円<br>(税込み)</span>
-                <div class='star-btn'>
-                  <%= image_tag "star.png", class:"star-icon" %>
-                  <span class='star-count'>0</span>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        </li>
-      <% end %> 
+      <%= render partial: "shared/item_lists", locals: { items: @like_items } %>
     </ul>
   </div>
 
+<%# コメントした商品 %>
   <div class='item-contents'>
-    <h2 class='title'>出品商品</h2>
+    <h2 class='title'>コメントした商品</h2>
     <ul class='item-lists'>
-      <% @my_items.each do |item| %>
-        <li class='list'>
-          <%= link_to item_path(item.id) do %>
-            <div class='item-img-content'>
-              <%# 1枚目の画像のみ表示, S3移行前の画像はno_images.pngに差し替え %>
-              <% if item.images.attached? && item.images.count > 0 %>
-                <%= image_tag item.images.first, class:'item-img' %>
-              <% else %>
-                <%= image_tag 'no_images.png', class: 'item-img' %>
-              <% end %>
+      <%= render partial: "shared/item_lists", locals: { items: @comment_items } %>
+    </ul>
+  </div>
 
-              <%# 商品が売れている場合 %>
-              <% if item.order != nil  %>
-                <div class='sold-out'>
-                  <span>Sold Out!!</span>
-                </div>
-              <% end %>  
-
-            </div>
-            <div class='item-info'>
-              <h3 class='item-name'>
-                <%= item.name %>
-              </h3>
-              <div class='item-price'>
-                <span><%= item.price %>円<br>(税込み)</span>
-                <div class='star-btn'>
-                 <%= image_tag "star.png", class:"star-icon" %>
-                  <span class='star-count'>0</span>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        </li>
-       <% end %> 
+  <%# 出品商品 %>
+  <div class='item-contents'>
+    <h2 class='title'>出品した商品</h2>
+    <ul class='item-lists'>
+      <%= render partial: "shared/item_lists", locals: { items: @my_items } %>
 
       <%# 商品がない場合のダミー %>
       <% if @my_items == nil %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :items do
     resources :orders, only: [:index, :create]
     resources :comments, only: [:create]
+    resources :likes, only: [:create, :destroy]
     collection do
       get 'search'
     end

--- a/db/migrate/20201022101903_create_likes.rb
+++ b/db/migrate/20201022101903_create_likes.rb
@@ -1,9 +1,8 @@
-class CreateComments < ActiveRecord::Migration[6.0]
+class CreateLikes < ActiveRecord::Migration[6.0]
   def change
-    create_table :comments do |t|
+    create_table :likes do |t|
       t.integer :user_id, null: false, foreign_key: true 
       t.integer :item_id, null: false, foreign_key: true 
-      t.text :text,       null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_21_095318) do
+ActiveRecord::Schema.define(version: 2020_10_22_101903) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -47,9 +47,9 @@ ActiveRecord::Schema.define(version: 2020_10_21_095318) do
   end
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "item_id"
-    t.text "text"
+    t.integer "user_id", null: false
+    t.integer "item_id", null: false
+    t.text "text", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -68,6 +68,13 @@ ActiveRecord::Schema.define(version: 2020_10_21_095318) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["price"], name: "index_items_on_price"
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :like do
+    
+  end
+end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :like do
-    
   end
 end

--- a/spec/helpers/likes_helper_spec.rb
+++ b/spec/helpers/likes_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the LikesHelper. For example:
+#
+# describe LikesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe LikesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/likes_request_spec.rb
+++ b/spec/requests/likes_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Likes", type: :request do
+
+end

--- a/spec/requests/likes_request_spec.rb
+++ b/spec/requests/likes_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
-RSpec.describe "Likes", type: :request do
-
+RSpec.describe 'Likes', type: :request do
 end


### PR DESCRIPTION
・お気に入り商品を登録し、欲しい商品を管理できるように機能を実装
・商品にお気に入りボタンを表示、likesテーブルにデータを登録
・既にお気に入りに登録した商品は、お気に入りから削除するボタンを表示し、likesテーブルからデータを削除できる
・マイページに、お気に入り商品を一覧で表示
・root_pathやマイページの商品一覧表示には、総お気に入り数を表示
・ログアウトユーザーがいいねしようとするとログインページへ遷移
・出品者本人や売却済みの商品に対しても、お気に入り登録は可能